### PR TITLE
L'appel API renvoie maintenant required avec un int

### DIFF
--- a/src/app/Http/Controllers/FieldsController.php
+++ b/src/app/Http/Controllers/FieldsController.php
@@ -151,11 +151,15 @@ class FieldsController extends Controller
     {
         if($request->user()->tokenCan("read")){
             $fields = Field::where("deleted",0)->where("status",2)->orderBy("order")->orderBy("required")->get()->toArray();
+            foreach ($fields as $key => $field){
+                $field["required"] = Field::convertRequiredAttribute($field["required"]);
+                $fields[$key] = $field;
+            }
             $datas["fields"] = $fields;
             foreach (ListControl::where("deleted",0)->whereIn("title",array_column($fields, "linked_list"))->get()->toArray() as $list){
                 $datas[$list["title"]] = ListControl::find($list["id"])->getListContent();
             }
-            return response(json_encode($datas), 200)->header('Content-Type', 'application/json');;
+            return response(json_encode($datas), 200)->header('Content-Type', 'application/json');
         }
         return response("Your token can't be use to read datas", 403);
 

--- a/src/app/Models/Field.php
+++ b/src/app/Models/Field.php
@@ -44,7 +44,7 @@ class Field extends Model
     /**
      * Return all hidden fields
      *
-     * @return array|string[]
+     * @return string
 
     public  function getHiddenValue(){
         return $this->hidden;
@@ -105,6 +105,35 @@ class Field extends Model
      */
     public function getRequiredId(){
         return $this->attributes['required'];
+    }
+
+    /**
+     * Convert a given requirement description into the associate int
+     *
+     * @param $value
+     * @return int
+     */
+    public static function convertRequiredAttribute($value){
+        switch ($value) {
+            case "Auto generated":
+                $int_required = 0;
+                break;
+            case "Required":
+                $int_required = 1;
+                break;
+            case "Strongly advised":
+                $int_required = 2;
+                break;
+            case "Advised":
+                $int_required = 3;
+                break;
+            case "If possible":
+                $int_required = 4;
+                break;
+            default:
+                $int_required = 100;
+        }
+        return $int_required;
     }
 
     /**


### PR DESCRIPTION
### Description
Retour de l'API GET avec required comme int et non comme texte descriptif

## Issues fixées
Liste des issues associées (mettre closed devant fermera automatiquement l'issue) :

- Closed #26
 

### Checklist
- [x] Ça compile / Pas de bug apparant
- [x] Le code est commenté
- [x] J'ai mis à jour le readme
